### PR TITLE
prevent segment from crashing inside pathChunk

### DIFF
--- a/rosencrantz/handlers.nim
+++ b/rosencrantz/handlers.nim
@@ -61,7 +61,7 @@ proc segment*(p: proc(s: string): Handler): Handler =
     template path: auto = req.url.path
 
     let pos = ctx.position
-    if path[pos] != '/':
+    if pos >= path.len or path[pos] != '/':
       return ctx.reject()
     let nextSlash = path.find('/', pos + 1)
     let final = if nextSlash == -1: path.len - 1 else: nextSlash - 1


### PR DESCRIPTION
minimal example:

```nim
let handler = pathChunk("/api")[
       segment(proc(s: string): auto =
          ok(s)
        )
     ]
```
expected:
`/api` -> 404
actual:
`/api` -> 500