### PR TITLE
Add pretty print support for JSON

### DIFF
--- a/tests/client.nim
+++ b/tests/client.nim
@@ -217,6 +217,16 @@ suite "json support":
     let resp = get(baseUrl & "/write-json")
     check resp.body.parseJson["msg"].getStr == "hi there"
     check resp.isOkJson
+  test "producing pretty json":
+    let resp = get(baseUrl & "/write-json-pretty")
+    check resp.body.parseJson["msg"].getStr == "hi there"
+    check resp.isOkJson
+    check resp.body.find('\n') != -1
+  test "producing non-pretty json":
+    let resp = get(baseUrl & "/write-json-non-pretty")
+    check resp.body.parseJson["msg"].getStr == "hi there"
+    check resp.isOkJson
+    check resp.body.find('\n') == -1
   test "reading json":
     let resp = post(baseUrl & "/read-json", body = $(%{"msg": %"hi there", "count": %5}))
     check resp.body == "hi there"

--- a/tests/server.nim
+++ b/tests/server.nim
@@ -145,6 +145,12 @@ let handler = get[
   path("/write-json")[
     ok(%{"msg": %"hi there", "count": %5})
   ] ~
+  path("/write-json-pretty")[
+    ok(%{"msg": %"hi there", "count": %5}, pretty=true)
+  ] ~
+  path("/write-json-non-pretty")[
+    ok(%{"msg": %"hi there", "count": %5}, pretty=false)
+  ] ~
   path("/write-json-typeclass")[
     ok(Message(message: "hi there", count: 5))
   ] ~


### PR DESCRIPTION
This leaves the default for producing JSON as is (compact form),  but provides an optional 'pretty' parameter so that more readable JSON can be produced.

Includes updated unit tests. 